### PR TITLE
Add Blockfrost -> cardano-api transaction conversion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ dist-profiled/
 dist/
 result*
 .direnv
+*.token

--- a/adawallet/adawallet.cabal
+++ b/adawallet/adawallet.cabal
@@ -45,12 +45,15 @@ library
   hs-source-dirs:       src
 
   exposed-modules:      AdaWallet
+                      , Transaction
 
   build-depends:        aeson             >= 1.5.6.0
                       , MissingH
+                      , blockfrost-api
+                      , blockfrost-client
                       , bytestring
                       , cardano-addresses
-                      , cardano-api ^>= 8.45.2
+                      , cardano-api ^>= 8.46
                       , cardano-cli ^>= 8.23
                       , cardano-prelude
                       , containers
@@ -60,6 +63,8 @@ library
                       , ouroboros-network-protocols
                       , parsec
                       , persistent-sqlite
+                      , pretty-simple
+                      , safe-money
                       , servant-client
                       , split
                       , stm

--- a/adawallet/src/AdaWallet.hs
+++ b/adawallet/src/AdaWallet.hs
@@ -15,6 +15,9 @@ import System.Directory (
  )
 import System.Environment (lookupEnv)
 import Prelude
+import Transaction
+import GHC.Stack
+import Data.Maybe
 
 main :: IO ()
 main = do
@@ -28,30 +31,27 @@ opts =
         --        <> command "init-restore" (info (pure restoreWallet "foo") (progDesc "Restore a wallet from mnemonic"))
         <> command "init-create" (info (pure createWallet) (progDesc "create a wallet"))
         --        <> command "import-accounts" (info (pure importAccounts 0 0) (progDesc "create a wallet"))
+        <> command "debug-rtx" (info (pure readTx) (progDesc "read tx from blockfrost and print"))
     )
 
-wipeCommand :: IO ()
+wipeCommand :: HasCallStack => IO ()
 wipeCommand = do
   stateDir' <- stateDir
   walletName' <- walletName
   let sqliteFile = stateDir' ++ "/" ++ walletName' ++ ".sqlite"
   removePathForcibly sqliteFile
 
-stateDir :: IO FilePath
+stateDir :: HasCallStack => IO FilePath
 stateDir = do
   fromEnv <- lookupEnv "ADAWALLET_STATE"
   let fromXdg = getXdgDirectory XdgData "adawallet"
   maybe fromXdg pure fromEnv
 
 walletName :: IO String
-walletName = do
-  fromEnv <- lookupEnv "ADAWALLET_NAME"
-  case fromEnv of
-    Nothing -> pure "default"
-    Just name -> pure name
+walletName = fromMaybe "default" <$> lookupEnv "ADAWALLET_NAME"
 
 -- TODO: do more than just create tables
-initialize :: IO ()
+initialize :: HasCallStack => IO ()
 initialize = do
   stateDir' <- stateDir
   createDirectoryIfMissing True stateDir'
@@ -73,27 +73,30 @@ restoreWallet :: String -> IO ()
 restoreWallet mmemonic = putStrLn "Not implemented yet"
 
 -- Creates a new wallet, prints to stdout and loads the private key into sqlite
-createWallet :: IO ()
+createWallet :: HasCallStack => IO ()
 createWallet = putStrLn "Not implemented yet"
 
 -- Restores a wallet from an exported json file comtaining account data with no secrets
-restoreWalletReadOnly :: FilePath -> IO ()
+restoreWalletReadOnly :: HasCallStack => FilePath -> IO ()
 restoreWalletReadOnly json_file = putStrLn "Not implemented yet"
 
 -- Exports accounts to json without secret keys
-exportAccountsNoSecrets :: FilePath -> IO ()
+exportAccountsNoSecrets :: HasCallStack => FilePath -> IO ()
 exportAccountsNoSecrets json_file = putStrLn "Not implemented yet"
 
 -- Imports accounts for an already restored wallet (0th index for payment/stake/drep/CC cold/CC hot)
-importAccounts :: Int -> Int -> IO ()
+importAccounts :: HasCallStack => Int -> Int -> IO ()
 importAccounts start end = putStrLn "Not implemented yet"
 
 -- Signs transaction
 -- TODO replace [String] with list of custom types to sign with
-signTx :: FilePath -> Int -> [String] -> IO ()
+signTx :: HasCallStack => FilePath -> Int -> [String] -> IO ()
 signTx fp account types = putStrLn "Not implemented yet"
 
 -- Signs multiple transactions in a tarball
 -- TODO replace [String] with list of custom types to sign with
-bulkSignTx :: FilePath -> Int -> [String] -> IO ()
+bulkSignTx :: HasCallStack => FilePath -> Int -> [String] -> IO ()
 bulkSignTx fp account types = putStrLn "Not implemented yet"
+
+readTx :: HasCallStack => IO ()
+readTx = readBfTx

--- a/adawallet/src/Transaction.hs
+++ b/adawallet/src/Transaction.hs
@@ -1,0 +1,127 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Transaction where
+
+import qualified Blockfrost.Client   as BF
+import           Cardano.Api         as Api
+import           Cardano.Api.Shelley
+import qualified Data.ByteString     as BS
+import qualified Data.Foldable       as Fld
+import qualified Data.Map.Strict     as Map
+import           Data.String         (IsString (..))
+import           Data.Text           (Text)
+import qualified Data.Text           as T
+import qualified Data.Text           as Text
+import qualified Data.Text.Encoding  as TE
+import qualified Data.Text.Encoding  as Text
+import           Money
+import           Numeric             (readHex)
+import           Prelude
+import           Text.Pretty.Simple
+import GHC.Stack
+import Data.Monoid
+import Data.Maybe (fromMaybe)
+import Data.Bifunctor
+
+
+readBfTx :: HasCallStack => IO ()
+readBfTx = do
+  -- a token for preview network
+  -- BLOCKFROST_TOKEN_PATH="$PATH/adawallet/blockfrost.preview.token"
+  prj <- BF.projectFromEnv
+  let address = "addr_test1wqh4yha0ndhwykrh9cuhr47nh2y97zvkls74h4jq6uhlpacujv3z3"
+      -- TODO figure this out dynamically
+      era = AlonzoEraOnwardsBabbage
+  (latestBlocks,  utxos) <- fmap (either (error . show) id) . BF.runBlockfrost prj $ do
+    latestBlocks <- BF.getLatestBlock
+    utxos <- BF.getAddressUtxos address
+    pure (latestBlocks, utxos)
+
+  pPrint latestBlocks
+  pPrint utxos
+  let apiTxs = toApiTxOut era address <$> utxos
+  pPrint apiTxs
+
+toApiUTxO
+  :: HasCallStack
+  => AlonzoEraOnwards era
+  -> BF.Address
+  -> [BF.AddressUtxo]
+  -> UTxO era
+toApiUTxO w addr =
+  Fld.foldl'
+    (\(UTxO acc) addrUTxO -> UTxO $ acc <> Map.singleton (toApiTxIn addrUTxO) (toApiTxOut w addr addrUTxO))
+    (UTxO mempty)
+
+toApiTxIn :: BF.AddressUtxo -> TxIn
+toApiTxIn adUTxO =
+  TxIn (fromString . Text.unpack . BF.unTxHash $ BF._addressUtxoTxHash adUTxO) (TxIx . fromIntegral $ BF._addressUtxoOutputIndex adUTxO)
+
+toApiTxOut
+  :: forall era. HasCallStack
+  => AlonzoEraOnwards era
+  -> BF.Address
+  -> BF.AddressUtxo
+  -> TxOut CtxUTxO era
+toApiTxOut w (BF.Address addr) addrUTxO =
+  case deserialiseAddress (AsAddress AsShelleyAddr) addr of
+    Nothing -> error $ "toApiTxOut: Shelley address deserialization failed: " <> Text.unpack addr
+    Just bech32Addr ->
+      let addrInEra = AddressInEra (ShelleyAddressInEra (alonzoEraOnwardsToShelleyBasedEra w)) bech32Addr
+          val = toLedgerValue (alonzoEraOnwardsToMaryEraOnwards w) $ Fld.foldl' (\acc amt -> acc <> toApiValue amt) mempty $ BF._addressUtxoAmount addrUTxO
+          mDatHash = BF._addressUtxoDataHash addrUTxO
+          mInlineDat = BF._addressUtxoInlineDatum addrUTxO
+          sbe = alonzoEraOnwardsToShelleyBasedEra w
+          v = shelleyBasedEraConstraints sbe $ TxOutValueShelleyBased sbe val :: TxOutValue era
+      -- NB: Blockfrost only returns the reference script hash
+      in TxOut addrInEra v (toApiDatum w mDatHash mInlineDat) ReferenceScriptNone
+
+toApiDatum
+  :: HasCallStack
+  => AlonzoEraOnwards era
+  -> Maybe BF.DatumHash
+  -> Maybe BF.InlineDatum
+  -> TxOutDatum CtxUTxO era
+toApiDatum w mDatumHash mInlineDatum = do
+  let era = alonzoEraOnwardsToCardanoEra w
+  case (mDatumHash, mInlineDatum) of
+    (Nothing, Nothing) -> TxOutDatumNone
+    (Just (BF.DatumHash dHash), Nothing) ->
+      TxOutDatumHash w $ fromString $ Text.unpack dHash
+    (_, Just (BF.InlineDatum (BF.ScriptDatumCBOR sCbor))) -> either error id $ do
+      let bytes = hexToByteString sCbor
+      sData <- first (("toApiDatum: Error deserializing inline datum: " <>) . show) $
+        deserialiseFromCBOR AsScriptData bytes
+      let hScriptData = unsafeHashableScriptData sData
+          hash = hashScriptDataBytes hScriptData
+      maybe (Left $ "Impossible case - unsupported era: " <> show (pretty era)) pure
+        . getFirst
+        . mconcat
+        . map First $
+          [ forEraInEonMaybe era $ \w ->
+              TxOutDatumInline w hScriptData
+          , forEraInEonMaybe era $ \w ->
+              TxOutDatumHash w hash
+          , Just TxOutDatumNone
+          ]
+
+toApiValue :: HasCallStack => BF.Amount -> Api.Value
+toApiValue (BF.AdaAmount ll)  = lovelaceToValue . fromInteger $ toInteger ll
+toApiValue (BF.AssetAmount a) = toApiMultiAsset a
+
+hexToByteString :: HasCallStack => T.Text -> BS.ByteString
+hexToByteString txt = BS.pack . map (fst . head . readHex . T.unpack) $ T.chunksOf 2 txt
+
+toApiMultiAsset :: HasCallStack => SomeDiscrete -> Api.Value
+toApiMultiAsset sDiscrete =
+  let aId = someDiscreteCurrency sDiscrete
+      q = someDiscreteAmount sDiscrete
+      (pId, aName) = Text.splitAt 56 aId
+      assetName =
+        either
+          (error $ "toApiMultiAsset: " <> Text.unpack aName <> " is not hex encoded")
+          id
+          (deserialiseFromRawBytesHex AsAssetName $ Text.encodeUtf8 aName)
+  in valueFromList [ (AssetId (fromString $ Text.unpack pId) assetName
+                   , fromInteger q)
+                   ]


### PR DESCRIPTION
Adds a new command which gets all UTXOs from blockfrost for an address, converts to cardano-api format and pretty prints to stdout.